### PR TITLE
DOCSP-39286 document requirement for gcc 12+

### DIFF
--- a/source/faq.txt
+++ b/source/faq.txt
@@ -35,7 +35,7 @@ following shell command:
 
 Why do I get a ``undefined symbol`` error when
 installing {+driver-short+} from source?
--------------------------------------------------------------------------------------------------------------------------
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
 If you experience this error, check if you have GCC version 12 or later
 installed. {+driver-short+} raises this error when GCC version 12 or later is

--- a/source/faq.txt
+++ b/source/faq.txt
@@ -33,7 +33,6 @@ following shell command:
 
    $ python -m pip install polars
 
-
 Why do I get ``linux-gnu.so: undefined symbol: _ZNK5arrow6Status`` when
 installing {+driver-short+} from source?
 ---------------------------------------------------------------------------------------

--- a/source/faq.txt
+++ b/source/faq.txt
@@ -33,9 +33,11 @@ following shell command:
 
    $ python -m pip install polars
 
+
 Why do I get ``linux-gnu.so: undefined symbol: _ZNK5arrow6Status`` when
 installing {+driver-short+} from source?
 ---------------------------------------------------------------------------------------
+
 If you experience this error, check if you have GCC version 12 or later
 installed. {+driver-short+} raises this error when GCC version 12 or later is
 not installed in your Linux environment. To learn more about requirements to

--- a/source/faq.txt
+++ b/source/faq.txt
@@ -19,7 +19,7 @@ Frequently Asked Questions
 
 This page contains frequently asked questions and their answers.
 
-Why Do I Get ``ModuleNotFoundError: No module named 'polars'`` When Using {+driver-short+}?
+Why do I get ``ModuleNotFoundError: No module named 'polars'`` when using {+driver-short+}?
 ---------------------------------------------------------------------------------------
 
 {+driver-short+} raises this error when an application attempts to use a {+driver-short+} API
@@ -32,3 +32,17 @@ following shell command:
 .. code-block:: sh
 
    $ python -m pip install polars
+
+Why do I get ``linux-gnu.so: undefined symbol: _ZNK5arrow6Status`` when
+installing {+driver-short+} from source?
+---------------------------------------------------------------------------------------
+If you experience this error, check if you have GCC version 12 or later
+installed. {+driver-short+} raises this error when GCC version 12 or later is
+not installed in your Linux environment. To learn more about requirements to
+install {+driver-short+} from source, see :doc:`Installing and Upgrading
+</docs-pymongo-arrow/installation>`.
+
+
+
+
+

--- a/source/faq.txt
+++ b/source/faq.txt
@@ -40,7 +40,7 @@ If you experience this error, check if you have GCC version 12 or later
 installed. {+driver-short+} raises this error when GCC version 12 or later is
 not installed in your Linux environment. To learn more about requirements to
 install {+driver-short+} from source, see :doc:`Installing and Upgrading
-</docs-pymongo-arrow/installation>`.
+<installation>`.
 
 
 

--- a/source/faq.txt
+++ b/source/faq.txt
@@ -19,7 +19,7 @@ Frequently Asked Questions
 
 This page contains frequently asked questions and their answers.
 
-Why do I get ``ModuleNotFoundError: No module named 'polars'`` when using {+driver-short+}?
+Why Do I Get ``ModuleNotFoundError: No module named 'polars'`` When Using {+driver-short+}?
 --------------------------------------------------------------------------------------------
 
 {+driver-short+} raises this error when an application attempts to use a {+driver-short+} API
@@ -33,7 +33,7 @@ following shell command:
 
    $ python -m pip install polars
 
-Why do I get an ``undefined symbol`` error when installing {+driver-short+} from source?
+Why Do I Get an ``undefined symbol`` Error When Installing {+driver-short+} from Source?
 ----------------------------------------------------------------------------------------------------
 
 {+driver-short+} raises this error when GCC version 12 or later is

--- a/source/faq.txt
+++ b/source/faq.txt
@@ -20,7 +20,7 @@ Frequently Asked Questions
 This page contains frequently asked questions and their answers.
 
 Why do I get ``ModuleNotFoundError: No module named 'polars'`` when using {+driver-short+}?
----------------------------------------------------------------------------------------
+--------------------------------------------------------------------------------------------
 
 {+driver-short+} raises this error when an application attempts to use a {+driver-short+} API
 that returns query result-sets as a ``polars.DataFrame`` instance without
@@ -33,9 +33,9 @@ following shell command:
 
    $ python -m pip install polars
 
-Why do I get ``linux-gnu.so: undefined symbol: _ZNK5arrow6Status`` when
+Why do I get a ``undefined symbol`` error when
 installing {+driver-short+} from source?
-------------
+-------------------------------------------------------------------------------------------------------------------------
 
 If you experience this error, check if you have GCC version 12 or later
 installed. {+driver-short+} raises this error when GCC version 12 or later is

--- a/source/faq.txt
+++ b/source/faq.txt
@@ -34,15 +34,12 @@ following shell command:
    $ python -m pip install polars
 
 Why do I get an ``undefined symbol`` error when installing {+driver-short+} from source?
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------
 
-If you experience this error, check if you have GCC version 12 or later
-installed. {+driver-short+} raises this error when GCC version 12 or later is
-not installed in your Linux environment. To learn more about requirements to
-install {+driver-short+} from source, see :doc:`Installing and Upgrading
+{+driver-short+} raises this error when GCC version 12 or later is
+not installed in your Linux environment. If you experience this error,
+ensure that you have GCC version 12 or later installed.
+
+To learn more about the requirements for
+installing {+driver-short+} from source, see :doc:`Installing and Upgrading
 <installation>`.
-
-
-
-
-

--- a/source/faq.txt
+++ b/source/faq.txt
@@ -33,8 +33,7 @@ following shell command:
 
    $ python -m pip install polars
 
-Why do I get a ``undefined symbol`` error when
-installing {+driver-short+} from source?
+Why do I get a ``undefined symbol`` error when installing {+driver-short+} from source?
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
 If you experience this error, check if you have GCC version 12 or later

--- a/source/faq.txt
+++ b/source/faq.txt
@@ -33,7 +33,7 @@ following shell command:
 
    $ python -m pip install polars
 
-Why do I get a ``undefined symbol`` error when installing {+driver-short+} from source?
+Why do I get an ``undefined symbol`` error when installing {+driver-short+} from source?
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
 If you experience this error, check if you have GCC version 12 or later

--- a/source/faq.txt
+++ b/source/faq.txt
@@ -35,7 +35,7 @@ following shell command:
 
 Why do I get ``linux-gnu.so: undefined symbol: _ZNK5arrow6Status`` when
 installing {+driver-short+} from source?
----------------------------------------------------------------------------------------
+------------
 
 If you experience this error, check if you have GCC version 12 or later
 installed. {+driver-short+} raises this error when GCC version 12 or later is

--- a/source/installation.txt
+++ b/source/installation.txt
@@ -109,7 +109,7 @@ Installing from source on Linux requires the following additional dependencies:
 - pkg-config
 
 To use {+driver-short+} with a PyMongo feature that requires an optional
-dependency, you must install PyMongo with the dependency manually.
+dependency, you must set the dependency as an option when you install PyMongo.
 
 .. note:: 
 

--- a/source/installation.txt
+++ b/source/installation.txt
@@ -90,25 +90,32 @@ command:
 Install from Source
 ~~~~~~~~~~~~~~~~~~~
 
-If the above options still do not allow you to install ``pymongoarrow`` on your
+If you can't use the above options to install ``pymongoarrow`` on your
 system, you can install from source. To learn how, see the `Contributing Guide
 <https://github.com/mongodb-labs/mongo-arrow/blob/main/bindings/python/CONTRIBUTING.md#installing-from-source>`__.
 
 Dependencies
 ^^^^^^^^^^^^
 
-{+driver-short+} requires the following:
+{+driver-short+} requires the following dependencies:
 
-- PyMongo>=4.4
-- PyArrow>=16,<16.1
+- PyMongo version 4.4 or later
+- PyArrow version 16
+
+Installing from source on Linux requires the following additional dependencies: 
+- GCC version 12 or later
+- CMake
+- pkg-config
 
 To use {+driver-short+} with a PyMongo feature that requires an optional
-dependency, users must install PyMongo with the dependency manually.
+dependency, you must install PyMongo with the dependency manually.
 
 .. note:: 
 
-   PyMongo's optional dependencies are detailed
-   `here <https://pymongo.readthedocs.io/en/stable/installation.html#dependencies>`__.
+   To learn more about PyMongo's optional dependencies, see
+   `Dependencies
+   <https://pymongo.readthedocs.io/en/stable/installation.html#dependencies>`__
+   in the PyMongo documentation.
 
 For example, to use {+driver-short+} with Client-Side Field Level Encryption,
 you must install PyMongo with the ``encryption`` option in addition to installing
@@ -118,7 +125,7 @@ you must install PyMongo with the ``encryption`` option in addition to installin
 
    $ python -m pip install 'pymongo[encryption]' pymongoarrow
 
-Applications intending to use {+driver-short+} APIs that return query result-sets
+Applications using {+driver-short+} APIs that return query result-sets
 as ``pandas.DataFrame`` instances, such as ``~pymongoarrow.api.find_pandas_all()``,
 must also have ``pandas`` installed:
 

--- a/source/installation.txt
+++ b/source/installation.txt
@@ -100,7 +100,7 @@ Dependencies
 {+driver-short+} requires the following dependencies:
 
 - PyMongo version 4.4 or later
-- PyArrow version 16
+- PyArrow version 16.0
 
 Installing from source on Linux requires the following additional dependencies: 
 

--- a/source/installation.txt
+++ b/source/installation.txt
@@ -103,6 +103,7 @@ Dependencies
 - PyArrow version 16
 
 Installing from source on Linux requires the following additional dependencies: 
+
 - GCC version 12 or later
 - CMake
 - pkg-config


### PR DESCRIPTION
I also have a question/something to think about for these docs. To install from source, the docs direct the user to go to the [installing from source](https://github.com/mongodb-labs/mongo-arrow/blob/main/bindings/python/CONTRIBUTING.md#installing-from-source) section of the PyMongoArrow contributing guide, which details the dependancies needed for both Linux and Mac installations. 

I added the Linux requirements onto the main docs [Installing and Updating page](https://preview-mongodbshuangela.gatsbyjs.io/pymongo-arrow/DOCSP-39286-document-gcc-12-req/installation/#install-from-source), due to the ticket requiring that documentation. However, I was wondering if I should also add the mac requirements (having a modern version of XCODE), as the ticket seemed to be raised because the user was unaware of the GCC 12+ requirement, which is also detailed on the installing from source section of the PyMongoArrow contributing guide. I'm concerned that if we do not further document the mac requirements on the main installation and updating page, we will run into another issue further down the line where we'll have to add it anyways, as currently those requirements are on a secondary page that users may be unlikely to click on. What do others think? 

I currently did not add it because it's out of the ticket's scope, but wanted to hear other opinions. Also, in addition to the ticket changes, I made some style changes based on the style guide. 

# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-golang/blob/master/REVIEWING.md)

JIRA - <https://jira.mongodb.org/browse/DOCSP-39286>
Staging - <https://preview-mongodbshuangela.gatsbyjs.io/pymongo-arrow/DOCSP-39286-document-gcc-12-req/>

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Are all the links working?
- [x] Are the [facets and meta keywords](https://wiki.corp.mongodb.com/display/DE/Docs+Taxonomy) accurate?
