### PR TITLE
Add missing meta descriptions

### DIFF
--- a/source/comparison.txt
+++ b/source/comparison.txt
@@ -16,6 +16,7 @@ Comparing to PyMongo
  
 .. meta::
    :keywords: PyMongo, equivalence 
+   :description: Compare the differences between PyMongoArrow and PyMongo, focusing on data reading and writing, BSON type support, and performance benchmarks.
 
 In this guide, you can learn about the differences between {+driver-short+} and the
 PyMongo driver. This guide assumes familiarity with basic :driver:`PyMongo

--- a/source/data-types.txt
+++ b/source/data-types.txt
@@ -16,6 +16,7 @@ Data Types
 
 .. meta::
    :keywords: support, conversions
+   :description: Explore PyMongoArrow's support for various BSON data types, including embedded arrays and documents, and learn about type identifiers and extension types for Arrow and Pandas.
 
 {+driver-short+} supports a majority of the BSON types.
 Because Arrow and Polars provide first-class support for Lists and Structs,

--- a/source/faq.txt
+++ b/source/faq.txt
@@ -16,6 +16,7 @@ Frequently Asked Questions
 
 .. meta::
    :keywords: help, troubleshoot
+   :description: Find solutions to common errors encountered when using PyMongoArrow, such as missing module or undefined symbol errors.
 
 This page contains frequently asked questions and their answers.
 

--- a/source/index.txt
+++ b/source/index.txt
@@ -10,6 +10,7 @@
 
 .. meta::
    :keywords: home, about
+   :description: Explore PyMongoArrow, a PyMongo extension for loading MongoDB query results as Apache Arrow tables, NumPy arrays, and Pandas or Polars DataFrames.
 
 .. toctree::
 

--- a/source/installation.txt
+++ b/source/installation.txt
@@ -16,6 +16,7 @@ Installing and Upgrading
 
 .. meta::
    :keywords: setup, download, update
+   :description: Learn how to install and upgrade PyMongoArrow using pip, conda, or from source, and understand its system and Python compatibility requirements.
 
 In this guide, you can learn how to install and upgrade {+driver-short+}.
 

--- a/source/previous-versions.txt
+++ b/source/previous-versions.txt
@@ -10,6 +10,7 @@ Previous Versions
  
 .. meta::
    :keywords: old, backwards, downgrade, upgrade
+   :description: Access documentation for previous versions of PyMongoArrow, including versions 1.2, 1.1, and 1.0.
 
 The following links direct you to documentation for previous versions of {+driver-short+}.
 

--- a/source/quick-start.txt
+++ b/source/quick-start.txt
@@ -16,6 +16,7 @@ Quick Start
  
 .. meta::
    :keywords: tutorial, introduction, setup, begin  
+   :description: Explore how to use PyMongoArrow for data manipulation in MongoDB, including inserting, querying, and writing data to various formats like Parquet and CSV.
 
 This tutorial is intended as an introduction to working with
 **{+driver-short+}**. The tutorial assumes the reader is familiar with basic

--- a/source/schemas.txt
+++ b/source/schemas.txt
@@ -16,6 +16,7 @@ Schema Examples
  
 .. meta::
    :keywords: pandas, numpy, flatten
+   :description: Explore how to use PyMongoArrow schemas for handling nested data and projections in MongoDB operations with Python.
 
 This guide shows examples of how to use PyMongoArrow schemas in common situations.
 

--- a/source/whats-new.txt
+++ b/source/whats-new.txt
@@ -16,6 +16,7 @@ What's New
  
 .. meta::
    :keywords: change, update, upgrade, compatible, backwards
+   :description: Discover the latest updates in PyMongoArrow, including new support for PyArrow 18.0, Python 3.13, and enhancements to prevent data loss and segmentation faults.
 
 Changes in Version 1.6.0
 ------------------------


### PR DESCRIPTION
Adds missing meta descriptions generated by the Education AI Team\n\nSOURCE: https://docs.google.com/spreadsheets/d/1fdrjF4Ms9fMl96zLiLGsYD_V38rTfPLuKs5VQk4vz6E/edit?gid=1166644539